### PR TITLE
refactor(raffle-client): remove lazy loading from i18n

### DIFF
--- a/packages/ps2/package.json
+++ b/packages/ps2/package.json
@@ -52,7 +52,6 @@
     "date-fns": "^2.28.0",
     "i18next": "^21.8.14",
     "i18next-browser-languagedetector": "^6.1.4",
-    "i18next-http-backend": "^1.4.1",
     "lodash": "^4.17.21",
     "mui-modal-provider": "^2.0.0",
     "react": "17.0.2",

--- a/packages/ps2/src/util/i18next.ts
+++ b/packages/ps2/src/util/i18next.ts
@@ -1,19 +1,14 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
-import Backend from 'i18next-http-backend';
 
 export const supportedLanguages = ['en', 'ru'];
 
 i18n
-  .use(Backend)
   .use(LanguageDetector)
   .use(initReactI18next)
   // for all options read: https://www.i18next.com/overview/configuration-options
   .init({
-    backend: {
-      loadPath: '/locales/{{lng}}/{{ns}}.json',
-    },
     debug: false,
     supportedLngs: supportedLanguages,
     defaultNS: 'common',
@@ -30,7 +25,7 @@ i18n
       },
     },
     react: {
-      useSuspense: false,
+      useSuspense: true,
     },
   });
 


### PR DESCRIPTION
I removed the lazy loading of the packages. The translation files should be small as of now and the backend is slow. If we ever end up with a very large translation file with a quicker backend, we can revisit this change.