### PR TITLE
fix(PS2): prevent modal from closing when parent component destroyed

### DIFF
--- a/packages/ps2/src/components/ZModal/use.tsx
+++ b/packages/ps2/src/components/ZModal/use.tsx
@@ -1,8 +1,8 @@
-import { ShowFnOutput, useModal } from 'mui-modal-provider';
+import { ShowFnOutput, useModal, UseModalOptions } from 'mui-modal-provider';
 import { useCallback } from 'react';
 
-export function useZModal() {
-  const { showModal, ...etc } = useModal();
+export function useZModal(options?: UseModalOptions) {
+  const { showModal, ...etc } = useModal(options);
   const ourShowModal = useCallback(
     (Component, props?) => {
       const modal: ShowFnOutput<void> = showModal(Component, {

--- a/packages/ps2/src/views/TraderService/components/ServiceProfileContainer/atoms/InvestButton.tsx
+++ b/packages/ps2/src/views/TraderService/components/ServiceProfileContainer/atoms/InvestButton.tsx
@@ -20,7 +20,7 @@ const InvestButton: React.FC<{
 }> = ({ service }) => {
   const { t } = useTranslation('service');
   const isAuthenticated = useIsAuthenticated();
-  const { showModal } = useZModal();
+  const { showModal } = useZModal({ disableAutoDestroy: true });
   const selectInvestment = useSetSelectedInvestment();
   const navigate = useNavigate();
   const { balance, isFetching } = useCurrentBalance(service.ssc);

--- a/packages/ps2/src/views/TraderService/components/ServiceProfileContainer/atoms/InvestedButton.tsx
+++ b/packages/ps2/src/views/TraderService/components/ServiceProfileContainer/atoms/InvestedButton.tsx
@@ -49,7 +49,7 @@ export const InvestedButtonBase: React.FC<{
   service: Service;
   investedAmount: string;
 }> = ({ service, investedAmount }) => {
-  const { showModal } = useZModal();
+  const { showModal } = useZModal({ disableAutoDestroy: true });
   const selectInvestment = useSetSelectedInvestment();
 
   const onClickEditInvestment = () => {


### PR DESCRIPTION
This is needed because when the investment is done, the Investment tag is invalidated. So below investedAmount is set, and InvestButton is then replaced by InvestedButtonBase so as the parent component was destroyed, the modal was also destroyed.
<img width="399" alt="image" src="https://user-images.githubusercontent.com/5314435/205655555-980db0f9-192d-46d8-9781-48aed572450d.png">
