### PR TITLE
fix(PS2): fixed double deploy

### DIFF
--- a/.github/workflows/deploy-ps2-test.yml
+++ b/.github/workflows/deploy-ps2-test.yml
@@ -3,10 +3,6 @@ on:
   push:
     branches:
       - test
-  workflow_run:
-    workflows: ["Auto-merge into test"]
-    types:
-      - completed
 
 jobs:
   pre_job:


### PR DESCRIPTION
 push to test now was getting triggered because we're using robozignaly pat

Signed-off-by: Alexander Mikhalchenko <alex@xfuturum.com>